### PR TITLE
Bug fixes in PentagoBitBoard

### DIFF
--- a/src/student_player/PentagoBitBoard.java
+++ b/src/student_player/PentagoBitBoard.java
@@ -345,7 +345,7 @@ public class PentagoBitBoard {
 					byte[][] swapsQ0 = new byte[4][2];
 					int initialCapacityQ0 = (QUAD_SIZE * QUAD_SIZE) * swaps.length;
 
-					Q0 = equalQuadrants.get(0).get(0);
+					Q0 = equalQuadrants.get(0);
 
 					// Generate first 3 swaps
 					for(int i = 0; i < identicalQuadrants.size(); i++) {

--- a/src/student_player/PentagoBitBoard.java
+++ b/src/student_player/PentagoBitBoard.java
@@ -345,7 +345,7 @@ public class PentagoBitBoard {
 					byte[][] swapsQ0 = new byte[4][2];
 					int initialCapacityQ0 = (QUAD_SIZE * QUAD_SIZE) * swaps.length;
 
-					Q0 = equalQuadrants.get(0);
+					Q0 = uniqueQuadrant.get(0);
 
 					// Generate first 3 swaps
 					for(int i = 0; i < identicalQuadrants.size(); i++) {

--- a/src/student_player/PentagoBitBoard.java
+++ b/src/student_player/PentagoBitBoard.java
@@ -514,6 +514,8 @@ public class PentagoBitBoard {
 	private void updateWinner() {
 		boolean playerWin = checkWin(this.turnPlayer);
 		boolean otherWin = checkWin((byte) (1 - this.turnPlayer));
+		
+		this.winner = NOBODY;
 
 		if (playerWin) { // Current player has won
 			this.winner = otherWin ? DRAW : this.turnPlayer;


### PR DESCRIPTION
# Two bugs were fixed
@kareemhalabi 

## Bug fix for winner attribute being stuck as a certain value.

Bug fix for when a game ending move is processed. (Move which leads to a win for either player or a draw.) When reverting the move that led to the game to end, the winner attribute would not be reverted to the constant NOBODY.

## Bug fix for invalid move generation

Bug fix for when getting non symmetrical moves. When there are three identical quadrants, some invalid moves were returned which would try to swap a quadrant with itself
